### PR TITLE
Add symlink to .inp file

### DIFF
--- a/annotate/export-latex.ily
+++ b/annotate/export-latex.ily
@@ -38,6 +38,27 @@
    ;; "return" normalized string
    str)
 
+% Temporary function to strip property values from #< > parts
+#(define (sanitize-prop-value prop)
+   (let ((key (car prop))
+         (value (cdr prop)))
+     (cond
+      ((or (string? value)
+           (eq? key 'grob-type)
+           (eq? key 'type))
+       value)
+      ((ly:grob? value) (assq-ref (ly:grob-property value 'meta) 'name))
+      ((ly:input-location? value)
+       (let ((location (ly:input-file-line-char-column value)))
+         (string-append (car location) " "
+           (string-append
+            (number->string (second location)) ":"
+            (number->string (third location)) ":"
+            (number->string (fourth location))))))
+      ((eq? 'grob-location key) "Can't display grob location yet")
+      ((eq? key 'input-file-name) (car value))
+      (else "Can't display yet"))))
+
 % Return a string list for the "remaining" properties,
 % formatted as a list of key=value arguments
 #(define (format-latex-remaining-properties type props loc-props)
@@ -50,7 +71,7 @@
              (cons (car p)
                (if (ly:music? (cdr p))
                    (format-ly-music (cdr p))
-                   (cdr p))))
+                   (sanitize-prop-value p))))
            props))
          (result '()))
      ;; Start with LaTeX command

--- a/annotate/export-latex.ily
+++ b/annotate/export-latex.ily
@@ -206,16 +206,8 @@
         (format "    {~a}"
           (assq-ref ann 'grob-type)))
 
-       ;; The actual message
-       ;; Invalid characters are escaped except for intended
-       ;; verbatim LaTeX code
-       (append-to-output-stringlist
-        (format "    {~a}"
-          (indent-multiline-latex-string
-           (assq-ref ann 'message))))
-
        ;; For a custom annotation we have to append
-       ;; the type as 7th argument
+       ;; the type as 6th argument
        (let ((type (assq-ref annotation-type-latex-commands
                      (assq-ref ann 'type))))
          (if (not type)

--- a/annotate/format.ily
+++ b/annotate/format.ily
@@ -43,9 +43,8 @@
            (ly:music-property music 'denominator)))
         ((eq? 'KeyChangeEvent (ly:music-property music 'name))
          (format "Key: ~a" (ly:music-property music 'tonic)))
-        (else "<LilyPond Music>"))
+        (else "(LilyPond Music)"))
        "No music found"))
-
 
 % Compose a message from the properties of an annotation
 % The 'cmd' argument should be

--- a/latex-package/scholarLY.sty
+++ b/latex-package/scholarLY.sty
@@ -759,7 +759,7 @@ compiles with:
 
 % critical remark:
 
-\newcommand{\criticalRemark}[6][]{%
+\newcommand{\criticalRemark}[5][]{%
   % set KEYS, defaults, then new from #1
     \resetkeys
       \let\KV@errx\@gobble% ignore unknown keys
@@ -801,7 +801,7 @@ compiles with:
 
 % musical issue:
 
-\newcommand{\musicalIssue}[6][]{%
+\newcommand{\musicalIssue}[5][]{%
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys
@@ -843,7 +843,7 @@ compiles with:
 
 % lilypond issue:
 
-\newcommand{\lilypondIssue}[6][]{%
+\newcommand{\lilypondIssue}[5][]{%
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys
@@ -885,7 +885,7 @@ compiles with:
 
 % question:
 
-\newcommand{\annotateQuestion}[6][]{%
+\newcommand{\annotateQuestion}[5][]{%
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys
@@ -927,7 +927,7 @@ compiles with:
 
 % todo:
 
-\newcommand{\annotateTodo}[6][]{%
+\newcommand{\annotateTodo}[5][]{%
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys
@@ -969,7 +969,7 @@ compiles with:
 
 % generic annotations:
 
-\newcommand{\annotation}[6][]{% generic annotation, for custom types
+\newcommand{\annotation}[5][]{% generic annotation, for custom types
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys

--- a/latex-package/usage-examples/annotate.annotations.inp
+++ b/latex-package/usage-examples/annotate.annotations.inp
@@ -1,0 +1,1 @@
+../../usage-examples/annotate.annotations.inp


### PR DESCRIPTION
This is to make the .inp file accessible from the
LaTeX package usage-example directory.

I still don't really understand your set-up, but this seems to make the referencing possible
without having to move the  `.inp` file around or changing the links _in_ `annotate.tex`.
