### PR TITLE
Do not export 'message' to LaTeX twice

### DIFF
--- a/annotate/export-latex.ily
+++ b/annotate/export-latex.ily
@@ -185,16 +185,8 @@
         (format "    {~a}"
           (assq-ref ann 'grob-type)))
 
-       ;; The actual message
-       ;; Invalid characters are escaped except for intended
-       ;; verbatim LaTeX code
-       (append-to-output-stringlist
-        (format "    {~a}"
-          (indent-multiline-latex-string
-           (assq-ref ann 'message))))
-
        ;; For a custom annotation we have to append
-       ;; the type as 7th argument
+       ;; the type as 6th argument
        (let ((type (assq-ref annotation-type-latex-commands
                      (assq-ref ann 'type))))
          (if (not type)

--- a/latex-package/scholarLY.sty
+++ b/latex-package/scholarLY.sty
@@ -759,7 +759,7 @@ compiles with:
 
 % critical remark:
 
-\newcommand{\criticalRemark}[6][]{%
+\newcommand{\criticalRemark}[5][]{%
   % set KEYS, defaults, then new from #1
     \resetkeys
       \let\KV@errx\@gobble% ignore unknown keys
@@ -801,7 +801,7 @@ compiles with:
 
 % musical issue:
 
-\newcommand{\musicalIssue}[6][]{%
+\newcommand{\musicalIssue}[5][]{%
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys
@@ -843,7 +843,7 @@ compiles with:
 
 % lilypond issue:
 
-\newcommand{\lilypondIssue}[6][]{%
+\newcommand{\lilypondIssue}[5][]{%
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys
@@ -885,7 +885,7 @@ compiles with:
 
 % question:
 
-\newcommand{\annotateQuestion}[6][]{%
+\newcommand{\annotateQuestion}[5][]{%
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys
@@ -927,7 +927,7 @@ compiles with:
 
 % todo:
 
-\newcommand{\annotateTodo}[6][]{%
+\newcommand{\annotateTodo}[5][]{%
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys
@@ -969,7 +969,7 @@ compiles with:
 
 % generic annotations:
 
-\newcommand{\annotation}[6][]{% generic annotation, for custom types
+\newcommand{\annotation}[5][]{% generic annotation, for custom types
 % set KEYS, defaults, then new from #1
   \resetkeys
     \let\KV@errx\@gobble% ignore unknown keys


### PR DESCRIPTION
If I'm not completely mistaken the message body is _only_ used
from the keyval entry and not from the last mandatory argument.

So it's cleaner to completely remove that.
