### PR TITLE
`annotate` documentation

### DIFF
--- a/annotate/README.md
+++ b/annotate/README.md
@@ -65,17 +65,76 @@ LaTeX if/when the annotations are typeset later in that manner.
 
 ## LaTeX-Specific Code
 
+This section is only relevant to projects which will later incorporate the *scholarLY* LaTeX package for
+typesetting the exported annotations.
+
+### General Usage
+
 Messages may include LaTeX code for annotations intended to be typeset later using the *scholarLY* LaTeX
 package. In the meantime, this means nothing for the LilyPond side except that Guile, LilyPond's 
-Scheme interpreter, will still interpret escape characters and will thus alter the code during compilation. 
+Scheme interpreter, will still interpret escape characters and thus may alter the code during compilation. 
 Therefore, in some cases, double backslashes 
 are necessary for certain LaTeX hooks to make it to the exported document.
+
+```lilypond
+\musicalIssue \with {
+  message = "This is a \\textit{message} with {\color{red} some LaTeX code}."
+} NoteHead b
+```
 
 In a similar vein, it is prudent to be conscious of symbols that may cause trouble for LaTeX such as
 `#`, `_`, and so on. Even if such a character is not present in the `message` property, *everything* 
 contained by any property will be parsed by LaTeX at least once.
 
-Please refer to the relevant subdirectory for more information on the *scholarLY* LaTeX package.
+### Footnotes
+
+We can organize LaTeX footnotes using similar protocol to the `footnote-text` property. As mentioned
+previously, `footnote-..` properties are only applied in LilyPond. They are purposed as *in-score*
+footnotes as traditionally used in LilyPond. LaTeX-specific footnotes can be implemented within a 
+message just as in a typical LaTeX document.
+
+```lilypond
+\criticalRemark \with {
+  message = "This is an annotation\footnote{some footnote text} with a footnote for LaTeX."
+}
+```
+
+*scholarLY* also provides a more comprehensive infrastructure for using such footnotes. Use the 
+built-in `ann-footnote` property to write a footnote for the entire annotation. *scholarLY* will
+automatically place the superscript at the end of the message (meaning after punctuation and any 
+particular message wrappers specified later by the user).
+
+```lilypond
+\annotateTodo \with {
+  message = "This is my annotation."
+  ann-footnote = "This is a footnote for the entire annotation."
+}
+```
+
+Footnotes nested within the message can be organized as such:
+
+```lilypond
+\lilypondIssue \with {
+  message = "This is an annotation\fnSomething with some\fnBlueNote custom footnote\fnRandom hooks."
+  fn-Something-txt = "This is the footnote text."
+  fn-Blue-Note-txt = "This is another footnote."
+  fn-R-a-n-d-o-m-txt = "This footnote, like the other two, will be expanded into the respective hook."
+}
+```
+
+Custom footnote hooks are generated with the syntax `fn-<custom name>-txt`. The *custom name* can include
+any number of hyphens; they will be removed by the parser and recreated as `\fn<custom name (without hyphens)>`.
+Therefore, as in the example above, we can use these unique macros and count on *scholarLY* to take care
+of automatically defining them.
+
+There are several improvements to be made to this functionality. Currently, the number of custom footnote
+hooks is limited to five. Also, the custom names are entirely case-sensitive; it may ultimately not be
+possible to overcome that, but that is a future issue yet to be completely looked into.
+
+### The LaTeX Package
+
+Please refer to the documentation in `scholarly/annotate/latex-package` for more information on the 
+*scholarLY* LaTeX package.
 
 ## Coloring Annotated Grobs, and Other Options
 
@@ -87,8 +146,8 @@ we can use a global boolean to turn this colorization on or off.
 \setOption scholarly.colorize ##t
 ```
 
-Other options are made available in `scholarly/annotate/config.ily`. That code includes further comments to 
-explain the handling of the various options.
+Other options are made available in `scholarly/annotate/config.ily`. That code includes further comments that 
+explain the abilities and handling of the various options.
 
 ## Sorting, Filtering
 
@@ -99,4 +158,8 @@ by using `\setOption`. As above, more details about this utility are written in 
 can indicate the importance of some annotations over others. We will be able to *annotate* (which means printing
 to console *and* to export) only the priorities that are specified and/or in the order that is specified.
 
-## Etc?
+## Further 
+
+`annotate` is currently *scholarLY*'s most rubost module. The possibilities are constantly shifting / growing; the
+best way to stay up-to-date with the project is by pulling the latest state of the repositories (both `oll-core` and
+`scholarly`) and viewing the issue trackers, where new feature requests are frequently being added to the list.

--- a/annotate/README.md
+++ b/annotate/README.md
@@ -3,7 +3,9 @@
 The *scholarLY* `annotate` module provides functionality to create annotations of musical 
 scores engraved with GNU LilyPond. Annotations can be controlled through a number of highly customizable 
 parameters, one of the most significant of which is its export capabilities which allow 
-annotations to be further processed by LaTeX (see `scholarly/latex-package`).
+annotations to be further processed by LaTeX (see `scholarly/latex-package`). Note that there are some
+issues with using `lilypond-book` and footnotes; see the issue tracker for updates on that until
+a workaround is implemented.
 
 The basic behavior for annotations is to be printed in the console log. *By default, 
 annotations are printed* (see `scholarly/annotate/config.ily`). At the beginning of
@@ -43,9 +45,9 @@ annotating the slur that follows.
 
 ## Footnotes
 
-Annotations can be made into footnotes by including the `footnote-offset` property. `footnote-text` may be
-included as well to indicate a footnote message different than the annotation message. If `footnote-text`
-is not present, *scholarLY* will automatically use `message`.
+Annotations can be made into LilyPond footnotes by including at least the `footnote-offset` property (which 
+implicitally triggers the footnote engraver). By default, *scholarLY* assumes `message` is the footnote text;
+the `footnote-text` may be included to indicate a footnote message different than the annotation message.
 
 ```lilypond
 \lilypondIssue \with {
@@ -60,7 +62,7 @@ is not present, *scholarLY* will automatically use `message`.
 } Accidental bf
 ```
 
-These footnotes will be engraved to the lilypond score as usual. Note that they are not acknowledged by
+These footnotes will be engraved to the LilyPond score, by LilyPond, as usual. Note that they are not acknowledged by
 LaTeX if/when the annotations are typeset later in that manner.
 
 ## LaTeX-Specific Code
@@ -111,25 +113,10 @@ particular message wrappers specified later by the user).
 }
 ```
 
-Footnotes nested within the message can be organized as such:
-
-```lilypond
-\lilypondIssue \with {
-  message = "This is an annotation\fnSomething with some\fnBlueNote custom footnote\fnRandom hooks."
-  fn-Something-txt = "This is the footnote text."
-  fn-Blue-Note-txt = "This is another footnote."
-  fn-R-a-n-d-o-m-txt = "This footnote, like the other two, will be expanded into the respective hook."
-}
-```
-
-Custom footnote hooks are generated with the syntax `fn-<custom name>-txt`. The *custom name* can include
-any number of hyphens; they will be removed by the parser and recreated as `\fn<custom name (without hyphens)>`.
-Therefore, as in the example above, we can use these unique macros and count on *scholarLY* to take care
-of automatically defining them.
-
-There are several improvements to be made to this functionality. Currently, the number of custom footnote
-hooks is limited to five. Also, the custom names are entirely case-sensitive; it may ultimately not be
-possible to overcome that, but that is a future issue yet to be completely looked into.
+*scholarLY* doesn't yet support custom footnote functionality, which is a major enhancement that 
+would allow the use of unique footnote hooks within the `message` property (like `\footnote<custom-name>` 
+or similar) which can be automatically routed by *scholarLY* to the corresponding text (set as
+additional properties, like `footnote-<custom-name>-text = "Here is the corresponding text."`).
 
 ### The LaTeX Package
 

--- a/annotate/README.md
+++ b/annotate/README.md
@@ -5,6 +5,18 @@ scores engraved with GNU LilyPond. Annotations can be controlled through a numbe
 parameters, one of the most significant of which is its export capabilities which allow 
 annotations to be further processed by LaTeX (see `scholarly/latex-package`).
 
+The basic behavior for annotations is to be printed in the console log. *By default, 
+annotations are printed* (see `scholarly/annotate/config.ily`). At the beginning of
+the music document, we can tell *scholarLY* which types of documents to export:
+
+```lilypond
+\setOption scholarly.annotate.export-targets #'(plaintext latex)
+```
+
+Those output files will automatically format annotations to be further processed by the
+relevant programs. Currently, *plaintext* and *latex* are available, while other types
+are on the wishlist (such as *scheme* and *markdown*).
+
 ## Basic Syntax
 
 Annotations are implemented a few possible ways. The most common usage is `<hook> <properties> <item> <music>`.
@@ -53,17 +65,38 @@ LaTeX if/when the annotations are typeset later in that manner.
 
 ## LaTeX-Specific Code
 
-Messages may include LaTeX code. Note that Guile, LilyPond's Scheme interpreter, will see escape characters
-as usual; so double backslashes are necessary for LaTeX hooks that begin with `t`, `something else?`, etc.
+Messages may include LaTeX code for annotations intended to be typeset later using the *scholarLY* LaTeX
+package. In the meantime, this means nothing for the LilyPond side except that Guile, LilyPond's 
+Scheme interpreter, will still interpret escape characters and will thus alter the code during compilation. 
+Therefore, in some cases, double backslashes 
+are necessary for certain LaTeX hooks to make it to the exported document.
 
-(example)
+In a similar vein, it is prudent to be conscious of symbols that may cause trouble for LaTeX such as
+`#`, `_`, and so on. Even if such a character is not present in the `message` property, *everything* 
+contained by any property will be parsed by LaTeX at least once.
 
-..
+Please refer to the relevant subdirectory for more information on the *scholarLY* LaTeX package.
 
-Mention hash symbol, etc. in LaTeX.
+## Coloring Annotated Grobs, and Other Options
 
-## Prioriizing, Filtering
+By default, *scholarLY* will colorize the annotated grobs according to the OLL option `scholarly.annotate.colors`.
+Those colors, which correspond to the annotation types, may be changed using OLL's `\setOption` utility. Similarly,
+we can use a global boolean to turn this colorization on or off.
 
-..
+```lilypond
+\setOption scholarly.colorize ##t
+```
+
+Other options are made available in `scholarly/annotate/config.ily`. That code includes further comments to 
+explain the handling of the various options.
+
+## Sorting, Filtering
+
+Annotations are sorted by *rhythmic location* by default. This can be changed to *author* or *type*
+by using `\setOption`. As above, more details about this utility are written in `scholarly/annotate/config.ily`.
+
+**Not yet implemented**, annotations will also be able to be filtered by various criteria. Foremost, *priority*
+can indicate the importance of some annotations over others. We will be able to *annotate* (which means printing
+to console *and* to export) only the priorities that are specified and/or in the order that is specified.
 
 ## Etc?

--- a/annotate/README.md
+++ b/annotate/README.md
@@ -1,0 +1,69 @@
+# scholarLY: Annotate
+
+The *scholarLY* `annotate` module provides functionality to create annotations of musical 
+scores engraved with GNU LilyPond. Annotations can be controlled through a number of highly customizable 
+parameters, one of the most significant of which is its export capabilities which allow 
+annotations to be further processed by LaTeX (see `scholarly/latex-package`).
+
+## Basic Syntax
+
+Annotations are implemented a few possible ways. The most common usage is `<hook> <properties> <item> <music>`.
+
+```lilypond
+\criticalRemark \with {
+  message = "This slur is too long."
+} Slur a( b)
+```
+
+The ***hook*** typically indicates the type of annotation: one of `\criticalRemark`, `\musicalIssue`, 
+`\lilypondIssue`, `\annotateTodo` and `\annotateQuestion`. Also available is the generic `\annotation`
+which requires a *type* property to be specified in the context mod (the `\with` block) that follows.
+
+The only mandatory ***property*** is usually `message`, though sometimes also `type` as just explained. Other
+properties unique to individual annotations can be specified. This is where properties such as `priority`
+(see *Sorting, Filtering* below), `apply` (see `scholarly/editorial-functions`) and `footnote-..` (see
+*Footnotes* below) are placed.
+
+***Item*** is the symbol name of the item being annotated. In the above example, "Slur" indicates we are 
+annotating the slur that follows.
+
+***Music*** is simply the instance of music that is engraved.
+
+## Footnotes
+
+Annotations can be made into footnotes by including the `footnote-offset` property. `footnote-text` may be
+included as well to indicate a footnote message different than the annotation message. If `footnote-text`
+is not present, *scholarLY* will automatically use `message`.
+
+```lilypond
+\lilypondIssue \with {
+  footnote-offset = #'(1 . 2)
+  message = "This is my message, and also the footnote text."
+} NoteHead a4
+
+\annotateTodo \with {
+  footnote-offset = #'(2 . 0)
+  footnote-text = "This is my footnote."
+  message = "This is my annotation message."
+} Accidental bf
+```
+
+These footnotes will be engraved to the lilypond score as usual. Note that they are not acknowledged by
+LaTeX if/when the annotations are typeset later in that manner.
+
+## LaTeX-Specific Code
+
+Messages may include LaTeX code. Note that Guile, LilyPond's Scheme interpreter, will see escape characters
+as usual; so double backslashes are necessary for LaTeX hooks that begin with `t`, `something else?`, etc.
+
+(example)
+
+..
+
+Mention hash symbol, etc. in LaTeX.
+
+## Prioriizing, Filtering
+
+..
+
+## Etc?


### PR DESCRIPTION
README only; outlines the module in its current state.
