### PR TITLE
Added Score-context to module.ily

### DIFF
--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -196,7 +196,8 @@ todo =
 %%%% All settings can be overridden in individual scores.
 
 \consistToContexts #annotationCollector
-  #'(Staff
+  #'(Score
+     Staff
      DrumStaff
      RhythmicStaff
      TabStaff


### PR DESCRIPTION
This context is needed to annotate \tempo
