### PR TITLE
Balloon text

### DIFF
--- a/annotate/README.md
+++ b/annotate/README.md
@@ -65,6 +65,27 @@ the `footnote-text` may be included to indicate a footnote message different tha
 These footnotes will be engraved to the LilyPond score, by LilyPond, as usual. Note that they are not acknowledged by
 LaTeX if/when the annotations are typeset later in that manner.
 
+## Balloon Text
+
+Annotations can also be engraved as balloon text. As with footnotes, the `balloon-offset` property tells *scholarLY*
+to do so. `message` is the default text, and `balloon-text` can optionally specify an alternative message.
+
+```lilypond
+\lilypondIssue \with {
+  balloon-offset = #'(1 . 2)
+  message = "This is my message, and also the balloon text."
+} NoteHead a4
+
+\annotateTodo \with {
+  balloon-offset = #'(2 . 0)
+  balloon-text = "This is my balloon text."
+  message = "This is my annotation message."
+} Accidental bf
+```
+
+Keep in mind that LilyPond isn't able to engrave balloon text to spanners (Slur, Hairpin, TrillSpanner, etc.) yet; 
+attempts to do so will cause it to crash upon compiling.
+
 ## LaTeX-Specific Code
 
 This section is only relevant to projects which will later incorporate the *scholarLY* LaTeX package for

--- a/annotate/README.md
+++ b/annotate/README.md
@@ -1,13 +1,13 @@
 # scholarLY: Annotate
 
-The *scholarLY* `annotate` module provides functionality to create annotations of musical 
-scores engraved with GNU LilyPond. Annotations can be controlled through a number of highly customizable 
-parameters, one of the most significant of which is its export capabilities which allow 
+The *scholarLY* `annotate` module provides functionality to create annotations of musical
+scores engraved with GNU LilyPond. Annotations can be controlled through a number of highly customizable
+parameters, one of the most significant of which is its export capabilities which allow
 annotations to be further processed by LaTeX (see `scholarly/latex-package`). Note that there are some
 issues with using `lilypond-book` and footnotes; see the issue tracker for updates on that until
 a workaround is implemented.
 
-The basic behavior for annotations is to be printed in the console log. *By default, 
+The basic behavior for annotations is to be printed in the console log. *By default,
 annotations are printed* (see `scholarly/annotate/config.ily`). At the beginning of
 the music document, we can tell *scholarLY* which types of documents to export:
 
@@ -29,7 +29,7 @@ Annotations are implemented a few possible ways. The most common usage is `<hook
 } Slur a( b)
 ```
 
-The ***hook*** typically indicates the type of annotation: one of `\criticalRemark`, `\musicalIssue`, 
+The ***hook*** typically indicates the type of annotation: one of `\criticalRemark`, `\musicalIssue`,
 `\lilypondIssue`, `\annotateTodo` and `\annotateQuestion`. Also available is the generic `\annotation`
 which requires a *type* property to be specified in the context mod (the `\with` block) that follows.
 
@@ -38,14 +38,14 @@ properties unique to individual annotations can be specified. This is where prop
 (see *Sorting, Filtering* below), `apply` (see `scholarly/editorial-functions`) and `footnote-..` (see
 *Footnotes* below) are placed.
 
-***Item*** is the symbol name of the item being annotated. In the above example, "Slur" indicates we are 
+***Item*** is the symbol name of the item being annotated. In the above example, "Slur" indicates we are
 annotating the slur that follows.
 
 ***Music*** is simply the instance of music that is engraved.
 
 ## Footnotes
 
-Annotations can be made into LilyPond footnotes by including at least the `footnote-offset` property (which 
+Annotations can be made into LilyPond footnotes by including at least the `footnote-offset` property (which
 implicitally triggers the footnote engraver). By default, *scholarLY* assumes `message` is the footnote text;
 the `footnote-text` may be included to indicate a footnote message different than the annotation message.
 
@@ -83,8 +83,8 @@ to do so. `message` is the default text, and `balloon-text` can optionally speci
 } Accidental bf
 ```
 
-Keep in mind that LilyPond isn't able to engrave balloon text to spanners (Slur, Hairpin, TrillSpanner, etc.) yet; 
-attempts to do so will cause it to crash upon compiling.
+Keep in mind that LilyPond isn't able to engrave balloon text to spanners (Slur, Hairpin, TrillSpanner, etc.) yet;
+attempts to do so will cause it to crash upon compiling. This is listed on the [LilyPond issue tracker] (https://sourceforge.net/p/testlilyissues/issues/2567/ "LilyIssues 2567").
 
 ## LaTeX-Specific Code
 
@@ -94,9 +94,9 @@ typesetting the exported annotations.
 ### General Usage
 
 Messages may include LaTeX code for annotations intended to be typeset later using the *scholarLY* LaTeX
-package. In the meantime, this means nothing for the LilyPond side except that Guile, LilyPond's 
-Scheme interpreter, will still interpret escape characters and thus may alter the code during compilation. 
-Therefore, in some cases, double backslashes 
+package. In the meantime, this means nothing for the LilyPond side except that Guile, LilyPond's
+Scheme interpreter, will still interpret escape characters and thus may alter the code during compilation.
+Therefore, in some cases, double backslashes
 are necessary for certain LaTeX hooks to make it to the exported document.
 
 ```lilypond
@@ -106,14 +106,14 @@ are necessary for certain LaTeX hooks to make it to the exported document.
 ```
 
 In a similar vein, it is prudent to be conscious of symbols that may cause trouble for LaTeX such as
-`#`, `_`, and so on. Even if such a character is not present in the `message` property, *everything* 
+`#`, `_`, and so on. Even if such a character is not present in the `message` property, *everything*
 contained by any property will be parsed by LaTeX at least once.
 
 ### Footnotes
 
 We can organize LaTeX footnotes using similar protocol to the `footnote-text` property. As mentioned
 previously, `footnote-..` properties are only applied in LilyPond. They are purposed as *in-score*
-footnotes as traditionally used in LilyPond. LaTeX-specific footnotes can be implemented within a 
+footnotes as traditionally used in LilyPond. LaTeX-specific footnotes can be implemented within a
 message just as in a typical LaTeX document.
 
 ```lilypond
@@ -122,9 +122,9 @@ message just as in a typical LaTeX document.
 }
 ```
 
-*scholarLY* also provides a more comprehensive infrastructure for using such footnotes. Use the 
+*scholarLY* also provides a more comprehensive infrastructure for using such footnotes. Use the
 built-in `ann-footnote` property to write a footnote for the entire annotation. *scholarLY* will
-automatically place the superscript at the end of the message (meaning after punctuation and any 
+automatically place the superscript at the end of the message (meaning after punctuation and any
 particular message wrappers specified later by the user).
 
 ```lilypond
@@ -134,14 +134,14 @@ particular message wrappers specified later by the user).
 }
 ```
 
-*scholarLY* doesn't yet support custom footnote functionality, which is a major enhancement that 
-would allow the use of unique footnote hooks within the `message` property (like `\footnote<custom-name>` 
+*scholarLY* doesn't yet support custom footnote functionality, which is a major enhancement that
+would allow the use of unique footnote hooks within the `message` property (like `\footnote<custom-name>`
 or similar) which can be automatically routed by *scholarLY* to the corresponding text (set as
 additional properties, like `footnote-<custom-name>-text = "Here is the corresponding text."`).
 
 ### The LaTeX Package
 
-Please refer to the documentation in `scholarly/annotate/latex-package` for more information on the 
+Please refer to the documentation in `scholarly/annotate/latex-package` for more information on the
 *scholarLY* LaTeX package.
 
 ## Coloring Annotated Grobs, and Other Options
@@ -154,7 +154,7 @@ we can use a global boolean to turn this colorization on or off.
 \setOption scholarly.colorize ##t
 ```
 
-Other options are made available in `scholarly/annotate/config.ily`. That code includes further comments that 
+Other options are made available in `scholarly/annotate/config.ily`. That code includes further comments that
 explain the abilities and handling of the various options.
 
 ## Sorting, Filtering
@@ -166,7 +166,7 @@ by using `\setOption`. As above, more details about this utility are written in 
 can indicate the importance of some annotations over others. We will be able to *annotate* (which means printing
 to console *and* to export) only the priorities that are specified and/or in the order that is specified.
 
-## Further 
+## Further
 
 `annotate` is currently *scholarLY*'s most rubost module. The possibilities are constantly shifting / growing; the
 best way to stay up-to-date with the project is by pulling the latest state of the repositories (both `oll-core` and

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -112,31 +112,30 @@
              #{ \once \override #item #'input-annotation = #props #}))))
          #{
           #tweak-command
-          #(cond
-             ;; we want a footnote:
-             ((assq-ref props 'footnote-offset)
-               (begin
-                 (if (not (assq-ref props 'footnote-text))
-                     (set! props (assoc-set! props 'footnote-text
-                                   (assq-ref props 'message))))
-                 (let ((offset (assq-ref props 'footnote-offset))
-                       (text (assq-ref props 'footnote-text)))
-	                  #{ \footnote #offset #text #item #})))
-             ;; we want balloon text:
-             ((assq-ref props 'balloon-offset)
-                (let* ((grob (list-ref item 0))
-                       (description (assoc-get grob all-grob-descriptions)))
-                  (if (member 'spanner-interface
-                         (assoc-get 'interfaces (assoc-get 'meta description)))
-                      ;; the grob is a spanner, so cancel the balloon
-                       (oll:warn "We can't give engrave balloon text to spanners yet. Balloon ignored for ~a" grob)
-                       (begin
-                         (if (not (assq-ref props 'balloon-text))
-                              (set! props (assoc-set! props 'balloon-text
-                                            (assq-ref props 'message))))
-                         (let ((offset (assq-ref props 'balloon-offset))
-                               (text (assq-ref props 'balloon-text)))
-                            #{ \balloonGrobText #grob #offset \markup { #text } #}))))))
+         #(if (assq-ref props 'footnote-offset)
+         ;; we want a footnote:
+           (begin
+             (if (not (assq-ref props 'footnote-text))
+                 (set! props (assoc-set! props 'footnote-text
+                               (assq-ref props 'message))))
+             (let ((offset (assq-ref props 'footnote-offset))
+                   (text (assq-ref props 'footnote-text)))
+                #{ \footnote #offset #text #item #})))
+         #(if (assq-ref props 'balloon-offset)
+         ;; we want balloon text:
+            (let* ((grob (list-ref item 0))
+                   (description (assoc-get grob all-grob-descriptions)))
+              (if (member 'spanner-interface
+                     (assoc-get 'interfaces (assoc-get 'meta description)))
+                  ;; the grob is a spanner, so cancel the balloon
+                   (oll:warn "We can't give engrave balloon text to spanners yet. Balloon ignored for ~a" grob)
+                   (begin
+                     (if (not (assq-ref props 'balloon-text))
+                          (set! props (assoc-set! props 'balloon-text
+                                        (assq-ref props 'message))))
+                     (let ((offset (assq-ref props 'balloon-offset))
+                           (text (assq-ref props 'balloon-text)))
+                        #{ \balloonGrobText #grob #offset \markup { #text } #})))))
       	  #(if
             ;; `apply` property is set; apply editorial function
             (assq-ref props 'apply)

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -112,37 +112,36 @@
              #{ \once \override #item #'input-annotation = #props #}))))
          #{
           #tweak-command
-          #(if (assq-ref props 'footnote-offset)
-          ;; If footnote offset present, make footnote
+          #(cond
+             ;; we want a footnote:
+             ((assq-ref props 'footnote-offset)
                (begin
                  (if (not (assq-ref props 'footnote-text))
-                     (set! props (assoc-set! props 'footnote-text (assq-ref props 'message))))
+                     (set! props (assoc-set! props 'footnote-text
+                                   (assq-ref props 'message))))
                  (let ((offset (assq-ref props 'footnote-offset))
                        (text (assq-ref props 'footnote-text)))
-		                  #{ \footnote #offset #text #item #}))
-              ;; ELSE, check if we want balloon text:
-               (if (assq-ref props 'balloon-offset)
-                  (let* ((grob (list-ref item 0))
-                         (description (assoc-get grob all-grob-descriptions)))
-                    (if (member 'spanner-interface
-                           (assoc-get 'interfaces
-                                      (assoc-get 'meta description)))
-                        ;; the grob is a spanner, so cancel the balloon
-                         (ly:input-warning (*location*) "We can't give engrave balloon
-                              text to spanners yet; balloon ignored.")
-                         (begin
-                           (if (not (assq-ref props 'balloon-text))
-                                (set! props (assoc-set! props 'balloon-text
-                                              (assq-ref props 'message))))
-                           (let ((offset (assq-ref props 'balloon-offset))
-                                 (text (assq-ref props 'balloon-text)))
-                                #{ \balloonGrobText #grob #offset \markup { #text } #}))))))
-	  #(if (assq-ref props 'apply)
-	  ;; If `apply` property used, apply editorial function
-	       (let ((edition (string->symbol (assoc-ref props 'apply))))
-                    (editorialFunction edition item mus))
-               mus)
-         #})
+	                  #{ \footnote #offset #text #item #})))
+             ;; we want balloon text:
+             ((assq-ref props 'balloon-offset)
+                (let* ((grob (list-ref item 0))
+                       (description (assoc-get grob all-grob-descriptions)))
+                  (if (member 'spanner-interface
+                         (assoc-get 'interfaces (assoc-get 'meta description)))
+                      ;; the grob is a spanner, so cancel the balloon
+                       (ly:input-warning (*location*) "We can't give engrave balloon text to spanners yet; balloon ignored.")
+                       (begin
+                         (if (not (assq-ref props 'balloon-text))
+                              (set! props (assoc-set! props 'balloon-text
+                                            (assq-ref props 'message))))
+                         (let ((offset (assq-ref props 'balloon-offset))
+                               (text (assq-ref props 'balloon-text)))
+                            #{ \balloonGrobText #grob #offset \markup { #text } #}))))))
+          ;; If `apply` property used, apply editorial function
+      	  #(if (assq-ref props 'apply)
+      	       (let ((edition (string->symbol (assoc-ref props 'apply))))
+                  (editorialFunction edition item mus))
+               mus) #})
         (begin
          (ly:input-warning (*location*) "Improper annotation. Maybe there are mandatory properties missing?")
          #{ #})))))

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -125,9 +125,9 @@
                   (let* ((grob (list-ref item 0))
                          (description (assoc-get grob all-grob-descriptions)))
                     (if (member 'spanner-interface
-                        ;; the grob is a spanner, so cancel the balloon
                            (assoc-get 'interfaces
                                       (assoc-get 'meta description)))
+                        ;; the grob is a spanner, so cancel the balloon
                          (ly:input-warning (*location*) "We can't give engrave balloon
                               text to spanners yet; balloon ignored.")
                          (begin

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -113,13 +113,31 @@
          #{
           #tweak-command
           #(if (assq-ref props 'footnote-offset)
-          ;; If offset present, add automatic footnote
+          ;; If footnote offset present, make footnote
                (begin
                  (if (not (assq-ref props 'footnote-text))
                      (set! props (assoc-set! props 'footnote-text (assq-ref props 'message))))
                  (let ((offset (assq-ref props 'footnote-offset))
                        (text (assq-ref props 'footnote-text)))
-		   #{ \footnote #offset #text #item #})))
+		                  #{ \footnote #offset #text #item #}))
+              ;; ELSE, check if we want balloon text:
+               (let ((grob (list-ref item 0)))
+                 (if (and (assq-ref props 'balloon-offset)
+                          ;; If is is one of these spanners, don't attempt to engrave:
+                          ;; These are just the most common ones, so this is a courtesy
+                          ;; conditional. The alternative is: LilyPond crashes when it
+                          ;; attempts to engrave balloon text to spanners.
+                          (not (equal? grob 'Slur))
+                          (not (equal? grob 'Hairpin))
+                          (not (equal? grob 'Tie))
+                          (not (equal? grob 'Glissando)))
+                     (begin
+                       (if (not (assq-ref props 'balloon-text))
+                            (set! props (assoc-set! props 'balloon-text
+                                          (assq-ref props 'message))))
+                       (let ((offset (assq-ref props 'balloon-offset))
+                             (text (assq-ref props 'balloon-text)))
+                            #{ \balloonGrobText #grob #offset \markup { #text } #})))))
 	  #(if (assq-ref props 'apply)
 	  ;; If `apply` property used, apply editorial function
 	       (let ((edition (string->symbol (assoc-ref props 'apply))))

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -129,7 +129,7 @@
                   (if (member 'spanner-interface
                          (assoc-get 'interfaces (assoc-get 'meta description)))
                       ;; the grob is a spanner, so cancel the balloon
-                       (ly:input-warning (*location*) "We can't give engrave balloon text to spanners yet; balloon ignored.")
+                       (oll:warn "We can't give engrave balloon text to spanners yet. Balloon ignored for ~a" grob)
                        (begin
                          (if (not (assq-ref props 'balloon-text))
                               (set! props (assoc-set! props 'balloon-text
@@ -137,8 +137,9 @@
                          (let ((offset (assq-ref props 'balloon-offset))
                                (text (assq-ref props 'balloon-text)))
                             #{ \balloonGrobText #grob #offset \markup { #text } #}))))))
-          ;; If `apply` property used, apply editorial function
-      	  #(if (assq-ref props 'apply)
+      	  #(if
+            ;; `apply` property is set; apply editorial function
+            (assq-ref props 'apply)
       	       (let ((edition (string->symbol (assoc-ref props 'apply))))
                   (editorialFunction edition item mus))
                mus) #})

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -121,23 +121,22 @@
                        (text (assq-ref props 'footnote-text)))
 		                  #{ \footnote #offset #text #item #}))
               ;; ELSE, check if we want balloon text:
-               (let ((grob (list-ref item 0)))
-                 (if (and (assq-ref props 'balloon-offset)
-                          ;; If is is one of these spanners, don't attempt to engrave:
-                          ;; These are just the most common ones, so this is a courtesy
-                          ;; conditional. The alternative is: LilyPond crashes when it
-                          ;; attempts to engrave balloon text to spanners.
-                          (not (equal? grob 'Slur))
-                          (not (equal? grob 'Hairpin))
-                          (not (equal? grob 'Tie))
-                          (not (equal? grob 'Glissando)))
-                     (begin
-                       (if (not (assq-ref props 'balloon-text))
-                            (set! props (assoc-set! props 'balloon-text
-                                          (assq-ref props 'message))))
-                       (let ((offset (assq-ref props 'balloon-offset))
-                             (text (assq-ref props 'balloon-text)))
-                            #{ \balloonGrobText #grob #offset \markup { #text } #})))))
+               (if (assq-ref props 'balloon-offset)
+                  (let* ((grob (list-ref item 0))
+                         (description (assoc-get grob all-grob-descriptions)))
+                    (if (member 'spanner-interface
+                        ;; the grob is a spanner, so cancel the balloon
+                           (assoc-get 'interfaces
+                                      (assoc-get 'meta description)))
+                         (ly:input-warning (*location*) "We can't give engrave balloon
+                              text to spanners yet; balloon ignored.")
+                         (begin
+                           (if (not (assq-ref props 'balloon-text))
+                                (set! props (assoc-set! props 'balloon-text
+                                              (assq-ref props 'message))))
+                           (let ((offset (assq-ref props 'balloon-offset))
+                                 (text (assq-ref props 'balloon-text)))
+                                #{ \balloonGrobText #grob #offset \markup { #text } #}))))))
 	  #(if (assq-ref props 'apply)
 	  ;; If `apply` property used, apply editorial function
 	       (let ((edition (string->symbol (assoc-ref props 'apply))))

--- a/usage-examples/balloon-text.ly
+++ b/usage-examples/balloon-text.ly
@@ -1,0 +1,36 @@
+\version "2.19.56"
+
+\include "oll-core/package.ily"
+\loadPackage \with {
+  modules = annotate
+} scholarly
+
+music = {
+  \new Voice \with { \consists "Balloon_engraver" } {
+    \criticalRemark
+      \with{
+        message = "my message/balloon-text"
+        balloon-offset = #'(-1 . -2)
+    } NoteHead a4(
+  b c') c'
+    \musicalIssue
+      \with{
+        message = "my message"
+        balloon-text = "my balloon text."
+        balloon-offset = #'(1 . 2)
+    } Stem a
+  b b
+    \question
+      \with{
+        message = "my message, but not balloon text"
+        % LilyPond can't engrave balloons to spanners yet,
+        % so it doesn't work here:
+        balloon-offset = #'(-0.5 . -2)
+      } Hairpin a\p\< b c'\!
+  }
+}
+
+
+\score {
+  \new Staff = "my staff" \music
+}

--- a/usage-examples/balloon-text.ly
+++ b/usage-examples/balloon-text.ly
@@ -7,26 +7,36 @@
 
 music = {
   \new Voice \with { \consists "Balloon_engraver" } {
+    
+    \once \override BalloonTextItem #'X-extent = ##f
     \criticalRemark
       \with{
-        message = "my message/balloon-text"
-        balloon-offset = #'(-1 . -2)
+        message = "message/balloon-text"
+        balloon-offset = #'(0.5 . -3)
     } NoteHead a4(
-  b c') c'
+    
+    b c') c'
+  
     \musicalIssue
       \with{
-        message = "my message"
+        message = "my message and footnote"
         balloon-text = "my balloon text."
-        balloon-offset = #'(1 . 2)
+        balloon-offset = #'(1 . 3)
+        footnote-offset = #'(-1 . 3)
     } Stem a
-  b b
+    
+    b b
+    
     \question
       \with{
         message = "my message, but not balloon text"
         % LilyPond can't engrave balloons to spanners yet,
         % so it doesn't work here:
         balloon-offset = #'(-0.5 . -2)
-      } Hairpin a\p\< b c'\!
+    } Hairpin a\p\< 
+      
+    b c'\!
+    
   }
 }
 


### PR DESCRIPTION
This adds balloon text functionality for annotations, similar to footnotes (uses `balloon-offset` and `balloon-text` properties).