### PR TITLE
adds ignored types option

### DIFF
--- a/editorial-functions/config.ily
+++ b/editorial-functions/config.ily
@@ -11,11 +11,17 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%% Global boolean to toggle editorial functions
+%%%% Global options to toggle editorial functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % By detault, scholarLY applies editorial functions when set.
-\registerOption scholarly.editorial.functions.apply ##t
+\registerOption scholarly.editorial-functions.apply ##t
+
+
+% By detault, scholarLY doesn't ignore any types.
+\registerOption scholarly.editorial-functions.ignored-types #`()
+
+
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -29,15 +35,14 @@
 
 % NOTE. these are *not* real suggestions, but placeholders for now.
 
-\registerOption scholarly.editorial.functions.addition
+\registerOption scholarly.editorial-functions.addition
 #`((NoteHead . ,parenthesize)
    (Slur . ,slurDashed))
 
-\registerOption scholarly.editorial.functions.deletion
+\registerOption scholarly.editorial-functions.deletion
 #`((NoteHead . ,parenthesize)
    (Slur . ,slurDotted))
 
-\registerOption scholarly.editorial.functions.emendation
+\registerOption scholarly.editorial-functions.emendation
 #`((NoteHead . ,parenthesize)
    (Slur . ,slurDashed))
-

--- a/editorial-functions/module.ily
+++ b/editorial-functions/module.ily
@@ -16,14 +16,19 @@ editorialFunction =
 #(define-music-function (type item mus)
    (symbol? symbol-list? ly:music?)
    (let ((edit (getChildOptionWithFallback
-		`(scholarly editorial functions ,type)
-		(last item)
-		#f)))
-     (if (and edit
-	      (getOption `(scholarly editorial functions apply)))
-         (if (ly:music-function? edit)
-             (edit mus)
-             #{ \once #edit #mus #})
+              		`(scholarly editorial-functions ,type)
+              		  (last item)
+              		#f))
+         (apply-edits (getOption `(scholarly editorial-functions apply)))
+         (ignored-type (memq type (getOption
+                                      `(scholarly editorial-functions ignored-types)))))
+     (if edit
+         (if (and apply-edits
+                  (not ignored-type))
+             (if (ly:music-function? edit)
+                 (edit mus)
+                 #{ \once #edit #mus #})
+             mus)
          (begin
            (oll:warn "Editorial command ~a not set for ~a." edit (car item))
            mus))))

--- a/editorial-functions/module.ily
+++ b/editorial-functions/module.ily
@@ -16,9 +16,9 @@ editorialFunction =
 #(define-music-function (type item mus)
    (symbol? symbol-list? ly:music?)
    (let ((edit (getChildOptionWithFallback
-              		`(scholarly editorial-functions ,type)
-              		  (last item)
-              		#f))
+                  `(scholarly editorial-functions ,type)
+                    (last item)
+                  #f))
          (apply-edits (getOption `(scholarly editorial-functions apply)))
          (ignored-type (memq type (getOption
                                       `(scholarly editorial-functions ignored-types)))))

--- a/usage-examples/editorial-commands.ly
+++ b/usage-examples/editorial-commands.ly
@@ -5,7 +5,7 @@
   modules = annotate
 } scholarly
 
-% \setOption scholarly.editorial.functions.apply ##f
+% \setOption scholarly.editorial-functions.apply ##f
 
 
 %{
@@ -13,7 +13,7 @@
 %   (commented out to verify that options load
 %   from editorial-functions/config [y])
 
-\setOption scholarly.editorial.functions.addition #`(
+\setOption scholarly.editorial-functions.addition #`(
   (Slur . ,slurDashed)
   (NoteHead . ,parenthesize))
 %}
@@ -25,7 +25,7 @@ longerfunction =
 #(define-music-function (mus) (ly:music?)
    #{ \once \set fontSize = -4 \parenthesize #mus #})
 
-\setOption scholarly.editorial.functions.deletion #`(
+\setOption scholarly.editorial-functions.deletion #`(
   (NoteHead . ,longerfunction))
 
 
@@ -33,7 +33,7 @@ longerfunction =
 % options can also be expressed in lilypond code blocks
 % (if they don't contain music functions):
 
-\setOption scholarly.editorial.functions.emendation #`(
+\setOption scholarly.editorial-functions.emendation #`(
   (Slur .
     ,#{
     \slurDotted \shape #'((0 . -0.5) (0 . -1.5) (0 . -3.5) (0 . -0.5)) Slur


### PR DESCRIPTION
does #55 for editorial functions

Also fixes the OLL-warning, which used to be set when either/both invalid edition or scholarly.editorial-functions.apply set to #f. Obviously we only want to send an error if the edition is invalid (i.e. not assigned to a function), and *not* send any errors when editions are simply toggled off.