### PR TITLE
add editorial -Shorthand and -Section functions

### DIFF
--- a/editorial-functions/config.ily
+++ b/editorial-functions/config.ily
@@ -15,7 +15,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % By detault, scholarLY applies editorial functions when set.
-\registerOption scholarly.editorial.functions.apply ##t
+\registerOption scholarly.editorial-functions.apply ##t
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -29,15 +29,14 @@
 
 % NOTE. these are *not* real suggestions, but placeholders for now.
 
-\registerOption scholarly.editorial.functions.addition
+\registerOption scholarly.editorial-functions.addition
 #`((NoteHead . ,parenthesize)
    (Slur . ,slurDashed))
 
-\registerOption scholarly.editorial.functions.deletion
+\registerOption scholarly.editorial-functions.deletion
 #`((NoteHead . ,parenthesize)
    (Slur . ,slurDotted))
 
-\registerOption scholarly.editorial.functions.emendation
+\registerOption scholarly.editorial-functions.emendation
 #`((NoteHead . ,parenthesize)
    (Slur . ,slurDashed))
-

--- a/editorial-functions/module.ily
+++ b/editorial-functions/module.ily
@@ -16,11 +16,11 @@ editorialFunction =
 #(define-music-function (type item mus)
    (symbol? symbol-list? ly:music?)
    (let ((edit (getChildOptionWithFallback
-		`(scholarly editorial functions ,type)
+		`(scholarly editorial-functions ,type)
 		(last item)
 		#f)))
      (if (and edit
-	      (getOption `(scholarly editorial functions apply)))
+	      (getOption `(scholarly editorial-functions apply)))
          (if (ly:music-function? edit)
              (edit mus)
              #{ \once #edit #mus #})
@@ -47,3 +47,64 @@ editorialEmendation =
 #(define-music-function (item mus)
    (symbol-list? ly:music?)
    (editorialFunction 'emendation item mus))
+
+
+
+%% editorialShorthand `type` `item`
+% - hooks the \edit macro to `editorialFunction type item`
+%
+% Ideally, this could be limited to only an { expression } argument following
+% the editorialShorthand invocation. Since the expression inside expands *before*
+% the invocation's arguments are applied to the context, that seems not possible.
+
+#(define edit-sect-state (make-hash-table))
+
+editorialShorthand =
+#(define-scheme-function (type item)
+  (symbol? symbol-list?)
+    (hash-set! edit-sect-state 'type type)
+    (hash-set! edit-sect-state 'item item)
+    #{#})
+
+edit =
+#(define-music-function (mus)
+  (ly:music?)
+  (let ((type (hash-ref edit-sect-state 'type))
+        (item (hash-ref edit-sect-state 'item)))
+    (editorialFunction type item mus)))
+
+
+%% editorialSection type item { music }
+% - applies edition for type/item pairing to music
+
+editorialSection =
+#(define-music-function (parser location properties type item sect)
+  ((ly:context-mod?) symbol? symbol-list? ly:music?)
+  (let* ((props (if properties (context-mod->props properties) #f))
+         (edit (getChildOptionWithFallback
+                  `(scholarly editorial-functions ,type)
+                    (car item)
+                  #f))
+         (apply-edits (getOption `(scholarly editorial-functions apply)))
+         ; TODO uncomment and commit the following once `editorial-opts` branch is merged
+         ;(ignored-type (memq type (getOption `(scholarly editorial-function ignored-types))))
+         (music (music-map
+            (lambda (m)
+              (if edit
+                  ; TODO change to: (and apply-edits (not ignored-type)):
+                  (if apply-edits
+                      (if (ly:music-function? edit)
+                            (edit m)
+                            #{ #edit #m #})
+                      m)
+                  (begin
+                    ; Send a message for each instance. Do we want to warn
+                    ; only once for the entire section though?
+                    (oll:warn "Editorial command ~a not set for ~a." edit (car item))
+                    m)))
+          sect))
+          ; function prop: applied to the group, such as large parens etc.
+          (fun (if props (assq-ref props 'function) #f)))
+      (if fun
+          (fun music)
+          music)))

--- a/editorial-functions/module.ily
+++ b/editorial-functions/module.ily
@@ -95,7 +95,7 @@ editorialSection =
                         (if apply-edits
                             (if (ly:music-function? edit)
                                   (edit m)
-                                  #{ #edit #m #})
+                                  #{ \once #edit #m #})
                             m)
                         (begin
                           ; Send a message for each instance. Do we want to warn

--- a/editorial-functions/module.ily
+++ b/editorial-functions/module.ily
@@ -89,20 +89,20 @@ editorialSection =
          ; TODO uncomment and commit the following once `editorial-opts` branch is merged
          ;(ignored-type (memq type (getOption `(scholarly editorial-function ignored-types))))
          (music (music-map
-            (lambda (m)
-              (if edit
-                  ; TODO change to: (and apply-edits (not ignored-type)):
-                  (if apply-edits
-                      (if (ly:music-function? edit)
-                            (edit m)
-                            #{ #edit #m #})
-                      m)
-                  (begin
-                    ; Send a message for each instance. Do we want to warn
-                    ; only once for the entire section though?
-                    (oll:warn "Editorial command ~a not set for ~a." edit (car item))
-                    m)))
-          sect))
+                  (lambda (m)
+                    (if edit
+                        ; TODO change to: (and apply-edits (not ignored-type)):
+                        (if apply-edits
+                            (if (ly:music-function? edit)
+                                  (edit m)
+                                  #{ #edit #m #})
+                            m)
+                        (begin
+                          ; Send a message for each instance. Do we want to warn
+                          ; only once for the entire section though?
+                          (oll:warn "Editorial command ~a not set for ~a." edit (car item))
+                          m)))
+                  sect))
           ; function prop: applied to the group, such as large parens etc.
           (fun (if props (assq-ref props 'function) #f)))
       (if fun

--- a/usage-examples/editorial-commands.ly
+++ b/usage-examples/editorial-commands.ly
@@ -5,7 +5,7 @@
   modules = annotate
 } scholarly
 
-% \setOption scholarly.editorial.functions.apply ##f
+% \setOption scholarly.editorial-functions.apply ##f
 
 
 %{
@@ -13,7 +13,7 @@
 %   (commented out to verify that options load
 %   from editorial-functions/config [y])
 
-\setOption scholarly.editorial.functions.addition #`(
+\setOption scholarly.editorial-functions.addition #`(
   (Slur . ,slurDashed)
   (NoteHead . ,parenthesize))
 %}
@@ -24,16 +24,20 @@
 longerfunction =
 #(define-music-function (mus) (ly:music?)
    #{ \once \set fontSize = -4 \parenthesize #mus #})
+transparentStem =
+#(define-music-function (mus) (ly:music?)
+   #{ \once \override Stem.transparent = ##t #mus #})
 
-\setOption scholarly.editorial.functions.deletion #`(
-  (NoteHead . ,longerfunction))
+\setOption scholarly.editorial-functions.deletion #`(
+  (NoteHead . ,longerfunction)
+  (Stem . ,transparentStem))
 
 
 
 % options can also be expressed in lilypond code blocks
 % (if they don't contain music functions):
 
-\setOption scholarly.editorial.functions.emendation #`(
+\setOption scholarly.editorial-functions.emendation #`(
   (Slur .
     ,#{
     \slurDotted \shape #'((0 . -0.5) (0 . -1.5) (0 . -3.5) (0 . -0.5)) Slur
@@ -48,11 +52,15 @@ music = {
 
 % using editions:
 
+    
+
     \criticalRemark
     \with{
         message = "A remark about adding the slur."
         apply = addition
     } Slur a4( b c') d'
+    
+    \mark \markup { in annotations }
 
     \musicalIssue
     \with{
@@ -60,6 +68,9 @@ music = {
         apply = addition
     } NoteHead a4( b c') d'
 
+  \break
+
+  
 
 % applying edition without an annotation
 %   NOTE: global toggle for editorial functions affects
@@ -68,7 +79,7 @@ music = {
 
     \editorialAddition Slur a4( b c') d'
 
-
+  \mark \markup { standalone }
 
 % using editions predefined by user:
 
@@ -86,10 +97,55 @@ music = {
     \with{
         message = "Should we remove the slur?"
         apply = emendation
-    } Slur a4( b c') d'
-
+    } Slur a4( b c') d' |
+    
+    
+    \break
+    
+    
+    
+    % Set the \edit macro as a shorthand:
+    
+    \editorialShorthand #'addition NoteHead 
+      c'8 \edit d' e' <a' \edit f'>
+      
+    \mark \markup { editorial shorthands "(\\edit)" }  
+      
+    \editorialShorthand #'addition Slur 
+      c' \edit c'( d') c'( e' f') \edit d'( c') d'8 c' b c'
+      
+      
+    \break 
+    
+    
+      
+    % Edit everything in the music of item and type, with
+    % optional prepend and append (perhaps large parens, etc.)
+    
+    \editorialSection #'addition NoteHead { 
+      \tuplet 5/4 {
+        c'4 b' b 
+        <c' e'>
+        c'8( d')
+      }
+    }
+    
+    \mark \markup { editorial sections }
+    
+    \editorialSection #'deletion Stem { 
+      f'4( g') f'( g')
+    }
+    
+    \editorialSection #'addition Slur {
+      f'8( g'4) f'8 a16( b c') e'( c'4)
+    }
+    
 }
 
 \score {
   \new Staff = "my staff" \music
+}
+
+\paper {
+  system-system-spacing.basic-distance = #20
 }


### PR DESCRIPTION
(does #58)

`\editorialShorthand type item` sets the `\edit mus` macro to `editorialFunction type item mus`, so one could:

```lilypond
\editorialShorthand #'addition NoteHead
a b c' \edit d' e' \edit f' \edit g'
```

`\editorialSection (\with {..}) type item { mus }` maps the function for the pair type and item to everything in mus (if compatible). The optional `\with` can contain a `function = ...` property to set a function which should be applied to the entire expression once.

```lilypond
\editorialSection #'addition Slur {
  a b( c' d') e'( f' g')
}

\editorialSection \with {
  function = #my-function
  } #'addition Slur {
  a b( c' d') e'( f' g')
}

```