### PR TITLE
Input-file patch

### DIFF
--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -78,7 +78,7 @@
        (if (= 1 (length input-file))
            ;; relative path to current directory => no parent available
            ;; solution: take the last element of the current working directory
-           (last (os-path-cwd-list))
+           (cons (last (os-path-cwd-list)) (last input-file))
            ;; absolute path, take second-to-last element
            (list-tail input-file (- (length input-file) 2))))
       ;; extract directory name (-> part/voice name)

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -74,7 +74,7 @@
       (props (context-mod->props properties))
       ;; retrieve a pair with containing directory and input file
       (input-file (string-split (car (ly:input-file-line-char-column (*location*))) #\/ ))
-      (ctx (list-tail input-file (- (length input-file) 2)))
+      (ctx (list-tail input-file (- (length input-file) 1)))
       ;; extract directory name (-> part/voice name)
       (input-directory (car ctx))
       ;; extract segment name

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -75,7 +75,7 @@
       ;; retrieve a pair with containing directory and input file
       (input-file (string-split (car (ly:input-file-line-char-column (*location*))) #\/ ))
       (ctx (list-tail input-file (- (length input-file)
-                                    (if (> (length input-file) 2) 2 1))))
+                                    (if (> (length input-file) 1) 2 1))))
       ;; extract directory name (-> part/voice name)
       (input-directory (car ctx))
       ;; extract segment name

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -74,7 +74,8 @@
       (props (context-mod->props properties))
       ;; retrieve a pair with containing directory and input file
       (input-file (string-split (car (ly:input-file-line-char-column (*location*))) #\/ ))
-      (ctx (list-tail input-file (- (length input-file) 1)))
+      (ctx (list-tail input-file (- (length input-file)
+                                    (if (> (length input-file) 2) 2 1))))
       ;; extract directory name (-> part/voice name)
       (input-directory (car ctx))
       ;; extract segment name

--- a/annotate/module.ily
+++ b/annotate/module.ily
@@ -74,8 +74,13 @@
       (props (context-mod->props properties))
       ;; retrieve a pair with containing directory and input file
       (input-file (string-split (car (ly:input-file-line-char-column (*location*))) #\/ ))
-      (ctx (list-tail input-file (- (length input-file)
-                                    (if (> (length input-file) 1) 2 1))))
+      (ctx
+       (if (= 1 (length input-file))
+           ;; relative path to current directory => no parent available
+           ;; solution: take the last element of the current working directory
+           (last (os-path-cwd-list))
+           ;; absolute path, take second-to-last element
+           (list-tail input-file (- (length input-file) 2))))
       ;; extract directory name (-> part/voice name)
       (input-directory (car ctx))
       ;; extract segment name


### PR DESCRIPTION
Fixes the input-file name getting procedure in annotate/module.ily.

This only takes effect is (length input-file) > 1.

Please test this of course, but I can't find a situation where it causes a problem anymore. Point and click stuff works. Exporting routines work.